### PR TITLE
Fix poor color contrast for chart layers against dark theme

### DIFF
--- a/app.js
+++ b/app.js
@@ -199,7 +199,7 @@ class TheseusVisualizer {
                 return (seriesIndex === 0) ? '#3bc7c7' : '#f0a33b';
             }
             const yearIdx = this.years.indexOf(seriesName);
-            return `hsl(${(180 + yearIdx * 40) % 360}, 70%, 55%)`;
+            return `hsl(${(180 + yearIdx * 40) % 360}, 85%, 70%)`;
         };
 
         // Create gradients for each series
@@ -279,7 +279,7 @@ class TheseusVisualizer {
         this.legend.innerHTML = '';
         const items = this.vizMode === 'identity'
             ? [{ label: 'Original Code', color: '#3bc7c7' }, { label: 'Refactored', color: '#f0a33b' }]
-            : this.years.map((y, i) => ({ label: y, color: `hsl(${(180 + i * 40) % 360}, 70%, 55%)` }));
+            : this.years.map((y, i) => ({ label: y, color: `hsl(${(180 + i * 40) % 360}, 85%, 70%)` }));
 
         items.forEach(item => {
             const div = document.createElement('div');


### PR DESCRIPTION
## Motivation and Context

Addresses issue #25 — user feedback on Reddit noted that deep purple and blue chart layers blend into the dark background (bg-gray-950), making data strata difficult to read.

## How Has This Been Tested

- All 10 existing tests pass
- Verified that the HSL color values (saturation 85%, lightness 70%) produce neon/pastel-style colors that maintain clear contrast against dark backgrounds across the full hue range (180°–340°)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the CONTRIBUTING document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chart color brightness and saturation for enhanced visual clarity
  * Updated legend color scheme to maintain consistency across non-identity visualization mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->