### PR TITLE
Remove timeout for update fossils job

### DIFF
--- a/.github/workflows/update-fossils.yml
+++ b/.github/workflows/update-fossils.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           poetry run python -m scripts.add_fossils
           poetry run python -m scripts.cleanup_data
-        timeout-minutes: 180
 
       - name: Push to chore/fossil-update
         env:


### PR DESCRIPTION
Removed timeout for the update fossils job in GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for automated maintenance tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->